### PR TITLE
Use AC_CONFIG_MACRO_DIRS / ACLOCAL_AMFLAGS.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,5 @@
+ACLOCAL_AMFLAGS=-I m4
+
 lib_LTLIBRARIES=libsonic_nas_ndi.la
 
 libsonic_nas_ndi_la_SOURCES= src/nas_ndi_init.c src/nas_ndi_utils.cpp \

--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,7 @@ AC_INIT([sonic-nas-ndi], [1.0.1], [sonicproject@gmail.com])
 AM_INIT_AUTOMAKE([foreign])
 AC_CONFIG_SRCDIR([config.h.in])
 AC_CONFIG_HEADERS([config.h])
+AC_CONFIG_MACRO_DIRS([m4])
 # Checks for programs.
 AC_PROG_CXX
 AC_PROG_CC


### PR DESCRIPTION
Avoid configure / libtool warnings by specifying directory for m4 macros.